### PR TITLE
Dylan/fix-demo-sdk-disparity (Init README, link to releases + sdk)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# SpacetimeDB Unity Engine Tutorial Demos
+
+## Overview
+
+* This repository contains the demo result from following the SpacetimeDB Unity "[Part 1 - Basic Multiplayer](https://spacetimedb.com/docs/unity/part-1)" tutorial, for both client and server. 
+* The [SpacetimeDB Unity SDK](https://github.com/clockworklabs/com.clockworklabs.spacetimedbsdk) is pre-included via the package manifest.
+
+## C# Documentation
+
+* The included [SpacetimeDB Unity SDK](https://github.com/clockworklabs/com.clockworklabs.spacetimedbsdk) uses the same code as the C# SDK. 
+
+* You can find the documentation for the C# SDK in the [C# SDK Reference](https://spacetimedb.com/docs/client-languages/csharp/csharp-sdk-reference).
+
+## Installation
+
+1. Download the latest [.unitypackage release](https://github.com/clockworklabs/SpacetimeDBUnityTutorial/releases).
+2. Open the `.unitypackage` within your Unity project.
+3. Publish your [server module](https://github.com/clockworklabs/SpacetimeDBUnityTutorial/tree/master/Part1/server) via [SpacetimeDB CLI](https://spacetimedb.com/install).
+
+## Usage
+
+1. Open the `Assets/Scenes/Main` scene and inspect the `GameManager` ScriptableObject as a starting point.
+2. See the Unity "[Part 1 - Basic Multiplayer](https://spacetimedb.com/docs/unity/part-1)" tutorial docs.
+3. See the [SpacetimeDB Unity SDK](https://github.com/clockworklabs/com.clockworklabs.spacetimedbsdk) README.
+
+## Part 1 - Basic Multiplayer
+
+* The [server](https://github.com/clockworklabs/SpacetimeDBUnityTutorial/tree/master/Part1/server) module example is included from the tutorial docs.
+* The [client](https://github.com/clockworklabs/SpacetimeDBUnityTutorial/tree/master/Part1/client) example is included from the tutorial docs.
+
+## TODO
+
+* Add the Unity demo result for [Part 2 - Resources and Scheduling](https://spacetimedb.com/docs/unity/part-2)
+* Add the Unity demo result for [Part 3 - BitCraft Mini](https://spacetimedb.com/docs/unity/part-3)


### PR DESCRIPTION
## About

Init'd a root README, linking to the [SpacetimeDBUnityTutorial Releases](https://github.com/clockworklabs/SpacetimeDBUnityTutorial/releases) section and covering the relationship between the SDK<>demo.

⚠️[This is a 2-part PR](https://docs.google.com/document/d/1JZ89H0vvxVvhTBXnKy1hvxBCIBntz8ZaiDHS-CzZNsc/edit): This will need to be approved alongside another [PR here on com.clockworklabs.spacetimedbsdk](https://github.com/clockworklabs/com.clockworklabs.spacetimedbsdk/pull/16).

## Why

- Because the SDK release section contains a .unitypackage of the demo (with the SDK as merely a manifest pkg requirement) and the SDK release section will be moved to this demo release section ( https://github.com/clockworklabs/SpacetimeDBUnityTutorial/releases )
- Adds clarity to this repo, why it's here, where it comes from and its relationships.